### PR TITLE
feat: add home page scaffold for all pages in home context

### DIFF
--- a/lib/app/screens/home.dart
+++ b/lib/app/screens/home.dart
@@ -41,7 +41,6 @@ class FlightPlanList extends ConsumerWidget {
           child: Text(
             'My Trips',
             style: TextStyle(
-              color: Colors.black,
               fontSize: 22.0,
               fontWeight: FontWeight.bold,
             ),
@@ -101,10 +100,7 @@ class FlightPlanList extends ConsumerWidget {
     if (plans.isEmpty) {
       return const Expanded(
         child: Center(
-          child: Text(
-            'No flight plans have been made.',
-            style: TextStyle(color: Colors.black),
-          ),
+          child: Text('No flight plans have been made.'),
         ),
       );
     }

--- a/lib/app/screens/home.dart
+++ b/lib/app/screens/home.dart
@@ -1,4 +1,5 @@
 import 'package:chai/app/widgets/buttons.dart';
+import 'package:chai/app/widgets/main_page_scaffold.dart';
 import 'package:chai/app/widgets/toasts.dart';
 import 'package:chai/controllers/auth.dart';
 import 'package:chai/models/flight_plan/flight_plan.dart';
@@ -15,95 +16,12 @@ class HomePage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final user = ref.watch(currentUserProvider);
+    final fullName = user.whenOrNull(data: (u) => u.name);
+    final name = fullName?.split(' ').elementAt(0);
 
-    return Scaffold(
-      body: Container(
-        decoration: const BoxDecoration(
-          image: DecorationImage(
-            image: AssetImage("assets/background2.png"),
-            fit: BoxFit.cover,
-          ),
-        ),
-        child: SafeArea(
-          bottom: false,
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              return Column(
-                children: [
-                  SizedBox(
-                    height: constraints.maxHeight * 0.2,
-                    child: Stack(
-                      children: [
-                        // Title message in the center
-                        Positioned(
-                          left: 16.0,
-                          bottom: 16.0,
-                          // child:
-                          child: user.maybeWhen(
-                            data: (u) {
-                              return Text(
-                                'Welcome, ${u.name}!',
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 24.0,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              );
-                            },
-                            orElse: () => const SizedBox.shrink(),
-                          ),
-                        ),
-                        // Notifications icon and circular image at the top right
-                        Positioned(
-                          right: 16.0,
-                          top: 16.0,
-                          child: Row(
-                            children: [
-                              IconButton(
-                                icon: const Icon(
-                                  Icons.notifications,
-                                  color: Colors.white,
-                                ),
-                                onPressed: () {},
-                              ),
-                              const SizedBox(width: 8.0),
-                              CircleAvatar(
-                                backgroundColor:
-                                    user.hasValue ? null : Colors.grey,
-                                backgroundImage: user.maybeWhen(
-                                  data: (u) {
-                                    final component =
-                                        Uri.encodeComponent(u.name);
-                                    return NetworkImage(
-                                        "https://ui-avatars.com/api/?name=$component");
-                                  },
-                                  orElse: () => null,
-                                ),
-                                radius: 20.0,
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Container(
-                    height: constraints.maxHeight * 0.8,
-                    decoration: const BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.only(
-                        topLeft: Radius.circular(30.0),
-                        topRight: Radius.circular(30.0),
-                      ),
-                    ),
-                    child: const FlightPlanList(),
-                  ),
-                ],
-              );
-            },
-          ),
-        ),
-      ),
+    return MainPageScaffold(
+      title: name != null ? 'Welcome, $name!' : null,
+      child: const FlightPlanList(),
     );
   }
 }

--- a/lib/app/screens/settings.dart
+++ b/lib/app/screens/settings.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/widgets.dart';
+
+class Settings extends StatelessWidget {
+  const Settings({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Placeholder();
+  }
+}

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 const Color primary = Color(0xFF148FC5);
-const Color secondary = Color(0xABABABAB);
+const Color secondary = Color(0xFFABABAB);
 const Color tertiary = Color(0xFFC1839F);
 const Color error = Color(0xFFAB0807);
 

--- a/lib/app/widgets/main_page_scaffold.dart
+++ b/lib/app/widgets/main_page_scaffold.dart
@@ -40,7 +40,7 @@ class MainPageScaffold extends StatelessWidget {
                                     title!,
                                     style: const TextStyle(
                                       color: Colors.white,
-                                      fontSize: 24.0,
+                                      fontSize: 30.0,
                                       fontWeight: FontWeight.bold,
                                     ),
                                   )
@@ -75,9 +75,9 @@ class MainPageScaffold extends StatelessWidget {
                   ),
                   Container(
                     height: constraints.maxHeight * 0.8,
-                    decoration: const BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.only(
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.surface,
+                      borderRadius: const BorderRadius.only(
                         topLeft: Radius.circular(30.0),
                         topRight: Radius.circular(30.0),
                       ),

--- a/lib/app/widgets/main_page_scaffold.dart
+++ b/lib/app/widgets/main_page_scaffold.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+class MainPageScaffold extends StatelessWidget {
+  final String? title;
+  final Widget child;
+
+  const MainPageScaffold({
+    required this.title,
+    required this.child,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          image: DecorationImage(
+            image: AssetImage("assets/background2.png"),
+            fit: BoxFit.cover,
+          ),
+        ),
+        child: SafeArea(
+          bottom: false,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return Column(
+                children: [
+                  SizedBox(
+                    height: constraints.maxHeight * 0.2,
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        Positioned(
+                          bottom: 16.0,
+                          child: Align(
+                            alignment: Alignment.center,
+                            child: title != null
+                                ? Text(
+                                    title!,
+                                    style: const TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 24.0,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  )
+                                : const SizedBox.shrink(),
+                          ),
+                        ),
+                        Positioned(
+                          top: 16.0,
+                          right: 16.0,
+                          child: Row(
+                            children: [
+                              IconButton(
+                                icon: const Icon(
+                                  Icons.notifications,
+                                  color: Colors.white,
+                                ),
+                                onPressed: () {},
+                              ),
+                              const SizedBox(width: 4),
+                              IconButton(
+                                icon: const Icon(
+                                  Icons.settings,
+                                  color: Colors.white,
+                                ),
+                                onPressed: () {},
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    height: constraints.maxHeight * 0.8,
+                    decoration: const BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.only(
+                        topLeft: Radius.circular(30.0),
+                        topRight: Radius.circular(30.0),
+                      ),
+                    ),
+                    child: child,
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This creates a common widget to encapsulate all home pages with that uses a common background, title (if necessary), and also adds notification and settings buttons.

This is what the new home page looks like:

<img src="https://github.com/user-attachments/assets/740cd3a8-52a0-429c-9298-c809eb45c0ca" width="300" />
