### PR TITLE
Flight search

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
         android:label="GateSoup"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+        
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/app/router/router.dart
+++ b/lib/app/router/router.dart
@@ -1,7 +1,12 @@
 import 'package:chai/app/screens/create_account.dart';
 import 'package:chai/app/screens/home.dart';
 import 'package:chai/app/screens/login.dart';
+import 'package:chai/app/screens/searchByAirport.dart';
+import 'package:chai/app/screens/searchByFlightNum.dart';
 import 'package:chai/app/screens/splash.dart';
+import 'package:chai/app/screens/searchHome.dart';
+import 'package:chai/app/screens/searchByFlightNum.dart';
+import 'package:chai/app/screens/searchByAirport.dart';
 import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -30,11 +35,29 @@ GoRouter router(RouterRef ref) {
         },
       ),
       GoRoute(
+        path: '/searchHome',
+        builder: (context, state) {
+          return const SearchHomeScreen();
+        },
+      ),
+      GoRoute(
         path: '/home',
         builder: (context, state) {
           return const HomePage();
         },
-      )
+      ),
+      GoRoute(
+        path: '/searchByFlightNum',
+        builder: (context, state) {
+          return const SearchByFlightNum();
+        },
+      ),
+      GoRoute(
+        path: '/searchByAirport',
+        builder: (context, state) {
+          return const SearchByAirport();
+        },
+      ),
     ],
   );
 }

--- a/lib/app/screens/home.dart
+++ b/lib/app/screens/home.dart
@@ -146,15 +146,26 @@ class FlightPlanList extends ConsumerWidget {
           ),
         ),
         //button will bring user to screen where user can search for flights
-        GSButton(
-          onPressed: () async {
-            final authController = ref.read(authControllerProvider.notifier);
-            if (context.mounted) {
-              context.go('/searchHome');
-            }
-          },
-          text: 'Search Flight',
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: ElevatedButton.icon(
+            onPressed: () async {
+              final authController = ref.read(authControllerProvider.notifier);
+              if (context.mounted) {
+                context.go('/searchHome');
+              }
+            },
+            icon: const Icon(Icons.search),
+            label: const Text(
+                style: TextStyle(fontWeight: FontWeight.bold), 'Search Flight'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color.fromARGB(255, 19, 143, 194),
+              iconColor: Colors.white,
+              foregroundColor: Colors.white,
+            ),
+          ),
         ),
+
         // Row of buttons at the bottom
         Padding(
           padding: const EdgeInsets.all(16.0),

--- a/lib/app/screens/home.dart
+++ b/lib/app/screens/home.dart
@@ -145,6 +145,16 @@ class FlightPlanList extends ConsumerWidget {
             ),
           ),
         ),
+        //button will bring user to screen where user can search for flights
+        GSButton(
+          onPressed: () async {
+            final authController = ref.read(authControllerProvider.notifier);
+            if (context.mounted) {
+              context.go('/searchHome');
+            }
+          },
+          text: 'Search Flight',
+        ),
         // Row of buttons at the bottom
         Padding(
           padding: const EdgeInsets.all(16.0),

--- a/lib/app/screens/searchByAirport.dart
+++ b/lib/app/screens/searchByAirport.dart
@@ -5,16 +5,132 @@ import 'package:chai/models/flight_plan/flight_plan.dart';
 import 'package:chai/repository/flight_plan.dart';
 import 'package:chai/repository/user.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart';
+import 'package:chai/providers/http_client.dart';
+import 'package:chai/utils/env.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'dart:convert';
+import 'dart:math';
 
-final myController = TextEditingController();
+String outputFlightNum = 'NA';
+String outputArrTime = 'NA';
+String outputDepTime = 'NA';
+String outputDepAP = 'NA';
+String outputArrAP = 'NA';
 
-class SearchByAirport extends ConsumerWidget {
+final depController = TextEditingController();
+final arrController = TextEditingController();
+final planNumController = TextEditingController();
+
+class SearchByAirport extends ConsumerStatefulWidget {
   const SearchByAirport({super.key});
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  _SearchByAirportState createState() => _SearchByAirportState();
+}
+
+class _SearchByAirportState extends ConsumerState<SearchByAirport> {
+  @override
+  Widget build(BuildContext context) {
+    Future<Map<String, dynamic>?> searchFlightAirport(
+        String depAir, String arrAir) async {
+      final baseURL = Env().baseURL;
+      try {
+        print('search depature aiport: $depAir');
+        print('search arrival aiport: $arrAir');
+        //authorize query
+        final client = ref.read(httpClientProvider);
+        //submit query
+        final response = await client
+            .get('/flights?departure_airport=SFO&arrival_airport=MIA');
+        final statusCode = response.statusCode;
+        //flight found
+        if (statusCode == 200) {
+          print('flight found');
+          final listData = jsonDecode(response.body) as List<dynamic>;
+
+          //REPLACE LATER!!! just gets information on first flight meeting parameters, must display flights as a list when we get more
+          print('$listData');
+          final data = listData[0];
+          ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+          //final data = jsonDecode(response.body) as Map<String, dynamic>;
+          setState(() {
+            outputFlightNum = data['flight_number'].toString();
+            outputArrTime = data['actual_arr_time'].toString();
+            outputDepTime = data['actual_dep_time'].toString();
+            outputDepAP = data['dep_name'].toString();
+            outputArrAP = data['arrival_name'].toString();
+          });
+          return data;
+        } else {
+          //flight not found
+          print('Failed to fetch pokemon data. Status code: $statusCode');
+          setState(() {
+            outputFlightNum = 'NA';
+            outputArrTime = 'NA';
+            outputDepTime = 'NA';
+            outputDepAP = 'NA';
+            outputArrAP = 'NA';
+            showDialog(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: Text('Error'),
+                content: Text('Invalid flight code.'),
+              ),
+            );
+          });
+        }
+      } catch (error) {
+        print("Invalid Flight. Error: $error");
+      }
+    }
+
+    Future<Map<String, dynamic>?> addToFlightPlan(
+        String flightNum, int planNum) async {
+      final baseURL = Env().baseURL;
+      try {
+        print('searchFlightNum: $flightNum');
+        //authorize query
+        final client = ref.read(httpClientProvider);
+        //submit query
+        final response = await client
+            .post('/flight_plans/$planNum', body: {"flightNumber": flightNum});
+        final statusCode = response.statusCode;
+        //flight found
+        if (statusCode == 200) {
+          final data = jsonDecode(response.body) as Map<String, dynamic>;
+          setState(() {
+            showDialog(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: Text('Success!'),
+                content: Text('Flight added to plan.'),
+              ),
+            );
+          });
+          return data;
+        } else {
+          //flight not found
+          print('Failed to add flight. Status code: $statusCode');
+          setState(() {
+            showDialog(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: Text('Error'),
+                content: Text(
+                    'Could not add flight to flight plan. \nInvalid flight code.'),
+              ),
+            );
+          });
+        }
+      } catch (error) {
+        print("Invalid Flight Code");
+      }
+    }
+
     final user = ref.watch(currentUserProvider);
     return Scaffold(
       body: Column(
@@ -44,41 +160,126 @@ class SearchByAirport extends ConsumerWidget {
           Align(
               alignment: Alignment.center,
               child: Padding(
-                padding: EdgeInsets.only(bottom: 400.0),
+                padding: EdgeInsets.only(top: 5.0),
                 child: Column(
                   children: [
+                    //USER INPUT FIELD HERE
                     SizedBox(
                       width: 300,
                       child: TextField(
+                        //allows for the transfer of info from text field to other places
+                        controller: depController,
                         decoration: InputDecoration(
-                          labelText: 'Starting Airport',
+                          labelText: 'Departure Airport Code',
                         ),
                       ),
                     ),
                     SizedBox(
                       width: 300,
                       child: TextField(
+                        //allows for the transfer of info from text field to other places
+                        controller: arrController,
                         decoration: InputDecoration(
-                          labelText: 'Destination Airport',
+                          labelText: 'Arrival Airport Code',
                         ),
                       ),
                     ),
-                    Padding(padding: const EdgeInsets.all(16.0)),
+                    //Search Submit button
+                    Padding(padding: const EdgeInsets.all(5.0)),
                     SizedBox(
                       width: 300,
                       child: ElevatedButton.icon(
                         onPressed: () async {
                           final authController =
                               ref.read(authControllerProvider.notifier);
-                          if (context.mounted) {
-                            context.go('/home');
-                          }
+                          //context.go('/home');
+                          String userInputDep = depController.text;
+                          String userInputArr = arrController.text;
+                          print(
+                              'USER INPUT:\nDepature Airport: $userInputDep\nArrival Airport: $userInputArr');
+                          final flightData = await searchFlightAirport(
+                              userInputDep, userInputArr);
                         },
                         icon: const Icon(Icons.search),
                         label: const Text('Search For Flight'),
                         style: ElevatedButton.styleFrom(
-                          backgroundColor:
-                              Colors.white, // Set the background color to white
+                          backgroundColor: Colors.white,
+                        ),
+                      ),
+                    ),
+
+                    //display current flight info
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Flight Code: $outputFlightNum',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Arrival Time: $outputArrTime',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Departure Time: $outputDepTime',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Startpoint: $outputDepAP',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Destination: $outputArrAP',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                    ),
+                    //number of flight plan that flight will be added to
+                    Padding(padding: EdgeInsets.only(bottom: 20.0)),
+                    SizedBox(
+                      width: 300,
+                      child: TextField(
+                        //allows for the transfer of info from text field to other places
+                        controller: planNumController,
+                        //only numbers allowed in text field
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.digitsOnly
+                        ],
+                        decoration: InputDecoration(
+                          labelText: 'Add Flight To This Plan',
+                        ),
+                      ),
+                    ),
+                    Padding(padding: EdgeInsets.only(bottom: 10.0)),
+                    SizedBox(
+                      width: 300,
+                      child: ElevatedButton.icon(
+                        onPressed: () async {
+                          final authController =
+                              ref.read(authControllerProvider.notifier);
+                          //context.go('/home');
+                          String userInput = outputFlightNum;
+                          //convert flight plan number input into int
+                          int userPlanNum = int.parse(planNumController.text);
+                          print('Adding Flight: $userInput');
+                          final flightData =
+                              await addToFlightPlan(userInput, userPlanNum);
+                        },
+                        label: const Text('Flight Plan Number'),
+                        icon: const Icon(Icons.arrow_forward),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.white,
                         ),
                       ),
                     ),

--- a/lib/app/screens/searchByAirport.dart
+++ b/lib/app/screens/searchByAirport.dart
@@ -24,7 +24,23 @@ String outputArrAP = 'NA';
 final depController = TextEditingController();
 final arrController = TextEditingController();
 final dateController = TextEditingController();
+final airlineController = TextEditingController();
 final planNumController = TextEditingController();
+
+airlineSwitcher? selectedAirline;
+
+//stuff for airline dropdown menu
+enum airlineSwitcher {
+  Southwest('Southwest Airlines', Colors.blue),
+  Alaska('Alaska Airlines', Colors.blue),
+  American('American Airlines', Colors.red),
+  Spirit('Spirit Airlines', Colors.orange),
+  United('Untied Airlines', Color.fromARGB(255, 18, 55, 85));
+
+  const airlineSwitcher(this.label, this.color);
+  final String label;
+  final Color color;
+}
 
 class SearchByAirport extends ConsumerStatefulWidget {
   const SearchByAirport({super.key});
@@ -219,12 +235,37 @@ class _SearchByAirportState extends ConsumerState<SearchByAirport> {
                     Padding(padding: const EdgeInsets.all(5.0)),
                     SizedBox(
                       width: 300,
-                      child: TextField(
-                        //allows for the transfer of info from text field to other places
-                        //controller: arrController,
-                        decoration: InputDecoration(
-                          labelText: 'Airline',
-                        ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          DropdownMenu<airlineSwitcher>(
+                            initialSelection: null,
+                            controller: airlineController,
+                            // requestFocusOnTap is enabled/disabled by platforms when it is null.
+                            // On mobile platforms, this is false by default. Setting this to true will
+                            // trigger focus request on the text field and virtual keyboard will appear
+                            // afterward. On desktop platforms however, this defaults to true.
+                            requestFocusOnTap: true,
+                            label: const Text('Airline'),
+                            onSelected: (airlineSwitcher? airline) {
+                              setState(() {
+                                selectedAirline = airline;
+                              });
+                            },
+                            dropdownMenuEntries: airlineSwitcher.values
+                                .map<DropdownMenuEntry<airlineSwitcher>>(
+                                    (airlineSwitcher airline) {
+                              return DropdownMenuEntry<airlineSwitcher>(
+                                value: airline,
+                                label: airline.label,
+                                enabled: airline.label != 'Grey',
+                                style: MenuItemButton.styleFrom(
+                                  foregroundColor: airline.color,
+                                ),
+                              );
+                            }).toList(),
+                          )
+                        ],
                       ),
                     ),
                     SizedBox(
@@ -242,8 +283,7 @@ class _SearchByAirportState extends ConsumerState<SearchByAirport> {
                             _selectDate();
                           }),
                     ),
-                    //Search Submit button
-                    Padding(padding: const EdgeInsets.all(5.0)),
+
                     //Search Submit button
                     Padding(padding: const EdgeInsets.all(5.0)),
                     SizedBox(

--- a/lib/app/screens/searchByAirport.dart
+++ b/lib/app/screens/searchByAirport.dart
@@ -1,0 +1,92 @@
+import 'package:chai/app/widgets/buttons.dart';
+import 'package:chai/app/widgets/toasts.dart';
+import 'package:chai/controllers/auth.dart';
+import 'package:chai/models/flight_plan/flight_plan.dart';
+import 'package:chai/repository/flight_plan.dart';
+import 'package:chai/repository/user.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+
+final myController = TextEditingController();
+
+class SearchByAirport extends ConsumerWidget {
+  const SearchByAirport({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = ref.watch(currentUserProvider);
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(
+              top: 100.0,
+            ),
+            //button to go back home
+            child: ElevatedButton.icon(
+              onPressed: () async {
+                final authController =
+                    ref.read(authControllerProvider.notifier);
+                if (context.mounted) {
+                  context.go('/searchHome');
+                }
+              },
+              icon: const Icon(Icons.arrow_back),
+              label: const Text('Back'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor:
+                    Colors.white, // Set the background color to white
+              ),
+            ),
+          ),
+          Align(
+              alignment: Alignment.center,
+              child: Padding(
+                padding: EdgeInsets.only(bottom: 400.0),
+                child: Column(
+                  children: [
+                    SizedBox(
+                      width: 300,
+                      child: TextField(
+                        decoration: InputDecoration(
+                          labelText: 'Starting Airport',
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: TextField(
+                        decoration: InputDecoration(
+                          labelText: 'Destination Airport',
+                        ),
+                      ),
+                    ),
+                    Padding(padding: const EdgeInsets.all(16.0)),
+                    SizedBox(
+                      width: 300,
+                      child: ElevatedButton.icon(
+                        onPressed: () async {
+                          final authController =
+                              ref.read(authControllerProvider.notifier);
+                          if (context.mounted) {
+                            context.go('/home');
+                          }
+                        },
+                        icon: const Icon(Icons.arrow_back),
+                        label: const Text('Search For Flight'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor:
+                              Colors.white, // Set the background color to white
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              )),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/screens/searchByAirport.dart
+++ b/lib/app/screens/searchByAirport.dart
@@ -74,7 +74,7 @@ class SearchByAirport extends ConsumerWidget {
                             context.go('/home');
                           }
                         },
-                        icon: const Icon(Icons.arrow_back),
+                        icon: const Icon(Icons.search),
                         label: const Text('Search For Flight'),
                         style: ElevatedButton.styleFrom(
                           backgroundColor:

--- a/lib/app/screens/searchByFlightNum.dart
+++ b/lib/app/screens/searchByFlightNum.dart
@@ -1,0 +1,92 @@
+import 'package:chai/app/widgets/buttons.dart';
+import 'package:chai/app/widgets/toasts.dart';
+import 'package:chai/controllers/auth.dart';
+import 'package:chai/models/flight_plan/flight_plan.dart';
+import 'package:chai/repository/flight_plan.dart';
+import 'package:chai/repository/user.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+
+final myController = TextEditingController();
+
+class SearchByFlightNum extends ConsumerWidget {
+  const SearchByFlightNum({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = ref.watch(currentUserProvider);
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(
+              top: 100.0,
+            ),
+            //button to go back home
+            child: ElevatedButton.icon(
+              onPressed: () async {
+                final authController =
+                    ref.read(authControllerProvider.notifier);
+                if (context.mounted) {
+                  context.go('/searchHome');
+                }
+              },
+              icon: const Icon(Icons.arrow_back),
+              label: const Text('Back'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor:
+                    Colors.white, // Set the background color to white
+              ),
+            ),
+          ),
+          Align(
+              alignment: Alignment.center,
+              child: Padding(
+                padding: EdgeInsets.only(bottom: 400.0),
+                child: Column(
+                  children: [
+                    SizedBox(
+                      width: 300,
+                      child: TextField(
+                        decoration: InputDecoration(
+                          labelText: 'Starting Airport',
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: TextField(
+                        decoration: InputDecoration(
+                          labelText: 'Destination Airport',
+                        ),
+                      ),
+                    ),
+                    Padding(padding: const EdgeInsets.all(16.0)),
+                    SizedBox(
+                      width: 300,
+                      child: ElevatedButton.icon(
+                        onPressed: () async {
+                          final authController =
+                              ref.read(authControllerProvider.notifier);
+                          if (context.mounted) {
+                            context.go('/home');
+                          }
+                        },
+                        icon: const Icon(Icons.arrow_back),
+                        label: const Text('Search For Flight'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor:
+                              Colors.white, // Set the background color to white
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              )),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/app/screens/searchByFlightNum.dart
+++ b/lib/app/screens/searchByFlightNum.dart
@@ -148,7 +148,7 @@ class _SearchByFlightNumState extends ConsumerState<SearchByFlightNum> {
           Align(
               alignment: Alignment.center,
               child: Padding(
-                padding: EdgeInsets.only(bottom: 100.0),
+                padding: EdgeInsets.only(top: 5.0),
                 child: Column(
                   children: [
                     //USER INPUT FIELD HERE
@@ -235,6 +235,7 @@ class _SearchByFlightNumState extends ConsumerState<SearchByFlightNum> {
                         ),
                       ),
                     ),
+                    Padding(padding: EdgeInsets.only(bottom: 10.0)),
                     SizedBox(
                       width: 300,
                       child: ElevatedButton.icon(

--- a/lib/app/screens/searchByFlightNum.dart
+++ b/lib/app/screens/searchByFlightNum.dart
@@ -187,35 +187,35 @@ class _SearchByFlightNumState extends ConsumerState<SearchByFlightNum> {
                       width: 300,
                       child: Text(
                         'Flight Code: $outputFlightNum',
-                        style: const TextStyle(fontSize: 20),
-                      ),
-                    ),
-                    SizedBox(
-                      width: 300,
-                      child: Text(
-                        'Arrival Time: $outputArrTime',
-                        style: const TextStyle(fontSize: 20),
+                        style: const TextStyle(fontSize: 15),
                       ),
                     ),
                     SizedBox(
                       width: 300,
                       child: Text(
                         'Departure Time: $outputDepTime',
-                        style: const TextStyle(fontSize: 20),
+                        style: const TextStyle(fontSize: 15),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Arrival Time: $outputArrTime',
+                        style: const TextStyle(fontSize: 15),
                       ),
                     ),
                     SizedBox(
                       width: 300,
                       child: Text(
                         'Startpoint: $outputDepAP',
-                        style: const TextStyle(fontSize: 20),
+                        style: const TextStyle(fontSize: 15),
                       ),
                     ),
                     SizedBox(
                       width: 300,
                       child: Text(
                         'Destination: $outputArrAP',
-                        style: const TextStyle(fontSize: 20),
+                        style: const TextStyle(fontSize: 15),
                       ),
                     ),
                     //number of flight plan that flight will be added to

--- a/lib/app/screens/searchByFlightNum.dart
+++ b/lib/app/screens/searchByFlightNum.dart
@@ -5,16 +5,75 @@ import 'package:chai/models/flight_plan/flight_plan.dart';
 import 'package:chai/repository/flight_plan.dart';
 import 'package:chai/repository/user.dart';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart';
+import 'package:chai/providers/http_client.dart';
+import 'package:chai/utils/env.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import 'dart:convert';
+import 'dart:math';
+
+String outputFlightNum = 'NA';
+String outputArrTime = 'NA';
+String outputDepTime = 'NA';
+String outputDepAP = 'NA';
+String outputArrAP = 'NA';
 
 final myController = TextEditingController();
 
-class SearchByFlightNum extends ConsumerWidget {
+class SearchByFlightNum extends ConsumerStatefulWidget {
   const SearchByFlightNum({super.key});
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  _SearchByFlightNumState createState() => _SearchByFlightNumState();
+}
+
+class _SearchByFlightNumState extends ConsumerState<SearchByFlightNum> {
+  @override
+  Widget build(BuildContext context) {
+    Future<Map<String, dynamic>?> searchNum(String flightNum) async {
+      final baseURL = Env().baseURL;
+      try {
+        print('searchFlightNum: $flightNum');
+        //authorize query
+        final client = ref.read(httpClientProvider);
+        //submit query
+        final response = await client.get('/flights/$flightNum');
+        final statusCode = response.statusCode;
+        //flight found
+        if (statusCode == 200) {
+          final data = jsonDecode(response.body) as Map<String, dynamic>;
+          setState(() {
+            outputFlightNum = data['flight_number'].toString();
+            outputArrTime = data['actual_arr_time'].toString();
+            outputDepTime = data['actual_dep_time'].toString();
+            outputDepAP = data['dep_name'].toString();
+            outputArrAP = data['arrival_name'].toString();
+          });
+          return data;
+        } else {
+          //flight not found
+          print('Failed to fetch pokemon data. Status code: $statusCode');
+          setState(() {
+            outputFlightNum = 'NA';
+            outputArrTime = 'NA';
+            outputDepTime = 'NA';
+            outputDepAP = 'NA';
+            outputArrAP = 'NA';
+            showDialog(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: Text('Error'),
+                content: Text('Invalid flight code.'),
+              ),
+            );
+          });
+        }
+      } catch (error) {
+        print("Invalid Flight Code");
+      }
+    }
+
     final user = ref.watch(currentUserProvider);
     return Scaffold(
       body: Column(
@@ -44,42 +103,74 @@ class SearchByFlightNum extends ConsumerWidget {
           Align(
               alignment: Alignment.center,
               child: Padding(
-                padding: EdgeInsets.only(bottom: 400.0),
+                padding: EdgeInsets.only(bottom: 300.0),
                 child: Column(
                   children: [
+                    //USER INPUT FIELD HERE
                     SizedBox(
                       width: 300,
                       child: TextField(
+                        //allows for the transfer of info from text field to other places
+                        controller: myController,
                         decoration: InputDecoration(
-                          labelText: 'Starting Airport',
+                          labelText: 'Flight Code',
                         ),
                       ),
                     ),
-                    SizedBox(
-                      width: 300,
-                      child: TextField(
-                        decoration: InputDecoration(
-                          labelText: 'Destination Airport',
-                        ),
-                      ),
-                    ),
-                    Padding(padding: const EdgeInsets.all(16.0)),
+                    Padding(padding: const EdgeInsets.all(5.0)),
                     SizedBox(
                       width: 300,
                       child: ElevatedButton.icon(
                         onPressed: () async {
                           final authController =
                               ref.read(authControllerProvider.notifier);
-                          if (context.mounted) {
-                            context.go('/home');
-                          }
+                          //context.go('/home');
+                          String userInput = myController.text;
+                          print('USER INPUT: $userInput');
+                          final flightData = await searchNum(userInput);
                         },
-                        icon: const Icon(Icons.arrow_back),
+                        icon: const Icon(Icons.search),
                         label: const Text('Search For Flight'),
                         style: ElevatedButton.styleFrom(
-                          backgroundColor:
-                              Colors.white, // Set the background color to white
+                          backgroundColor: Colors.white,
                         ),
+                      ),
+                    ),
+
+                    //display current flight info
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Flight Code: $outputFlightNum',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Arrival Time: $outputArrTime',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Departure Time: $outputDepTime',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Startpoint: $outputDepAP',
+                        style: const TextStyle(fontSize: 20),
+                      ),
+                    ),
+                    SizedBox(
+                      width: 300,
+                      child: Text(
+                        'Destination: $outputArrAP',
+                        style: const TextStyle(fontSize: 20),
                       ),
                     ),
                   ],

--- a/lib/app/screens/searchHome.dart
+++ b/lib/app/screens/searchHome.dart
@@ -90,24 +90,6 @@ class SearchHomeScreen extends ConsumerWidget {
                 child: Column(
                   children: [
                     Padding(padding: const EdgeInsets.all(0.0)),
-                    SizedBox(
-                      width: 300,
-                      child: ElevatedButton.icon(
-                        onPressed: () async {
-                          final authController =
-                              ref.read(authControllerProvider.notifier);
-                          if (context.mounted) {
-                            context.go('/home');
-                          }
-                        },
-                        icon: const Icon(Icons.search),
-                        label: const Text('Search For Flight'),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor:
-                              Colors.white, // Set the background color to white
-                        ),
-                      ),
-                    ),
                   ],
                 ),
               )),

--- a/lib/app/screens/searchHome.dart
+++ b/lib/app/screens/searchHome.dart
@@ -1,0 +1,118 @@
+import 'package:chai/app/widgets/buttons.dart';
+import 'package:chai/app/widgets/toasts.dart';
+import 'package:chai/controllers/auth.dart';
+import 'package:chai/models/flight_plan/flight_plan.dart';
+import 'package:chai/repository/flight_plan.dart';
+import 'package:chai/repository/user.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+
+final myController = TextEditingController();
+
+class SearchHomeScreen extends ConsumerWidget {
+  const SearchHomeScreen({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = ref.watch(currentUserProvider);
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(
+              top: 75.0,
+            ),
+            //button to go back home
+            child: ElevatedButton.icon(
+              onPressed: () async {
+                final authController =
+                    ref.read(authControllerProvider.notifier);
+                if (context.mounted) {
+                  context.go('/home');
+                }
+              },
+              icon: const Icon(Icons.arrow_back),
+              label: const Text('Back Home'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor:
+                    Colors.white, // Set the background color to white
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(
+              top: 75.0,
+            ),
+            //button to go back home
+            child: ElevatedButton.icon(
+              onPressed: () async {
+                final authController =
+                    ref.read(authControllerProvider.notifier);
+                if (context.mounted) {
+                  context.go('/searchByAirport');
+                }
+              },
+              label: const Text('Search Flight By Airports'),
+              icon: const Icon(Icons.arrow_forward),
+              style: ElevatedButton.styleFrom(
+                backgroundColor:
+                    Colors.white, // Set the background color to white
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(
+              top: 0.0,
+            ),
+            //button to go back home
+            child: ElevatedButton.icon(
+              onPressed: () async {
+                final authController =
+                    ref.read(authControllerProvider.notifier);
+                if (context.mounted) {
+                  context.go('/searchByFlightNum');
+                }
+              },
+              label: const Text('Search Flight By Flight Number'),
+              icon: const Icon(Icons.arrow_forward),
+              style: ElevatedButton.styleFrom(
+                backgroundColor:
+                    Colors.white, // Set the background color to white
+              ),
+            ),
+          ),
+          Align(
+              alignment: Alignment.center,
+              child: Padding(
+                padding: EdgeInsets.only(bottom: 400.0),
+                child: Column(
+                  children: [
+                    Padding(padding: const EdgeInsets.all(0.0)),
+                    SizedBox(
+                      width: 300,
+                      child: ElevatedButton.icon(
+                        onPressed: () async {
+                          final authController =
+                              ref.read(authControllerProvider.notifier);
+                          if (context.mounted) {
+                            context.go('/home');
+                          }
+                        },
+                        icon: const Icon(Icons.search),
+                        label: const Text('Search For Flight'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor:
+                              Colors.white, // Set the background color to white
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              )),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Users can access flight search button from home page.
Then a new menu appears, asking users if they want to search for flight by dep and arr airports or directly by flight number.
Then they can go to a new screen where they can do this. Successful searches display flight info, unsuccessful display error popup.

Then, users must choose which plan to add flight to. Flight numbers are hidden at the moment, so we have to use the ids from bruno for now. Then, bottom button adds flight to designated flight plan. Everything works well enough. At least... I think it does. Works on my end anyways.

Ugly interface, but works good enough for prototype I thinks.